### PR TITLE
Switched to PhantomJS webdriver

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 beautifulsoup4==4.3.2
 python-dateutil==2.4.2
+scraperwiki==0.5
 selenium==2.46.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 beautifulsoup4==4.3.2
 python-dateutil==2.4.2
-scraperwiki==0.5
 selenium==2.46.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 beautifulsoup4==4.3.2
 python-dateutil==2.4.2
-scraperwiki==0.5
+# Install custom version of scraperwiki library that used morph naming conventions
+-e git+http://github.com/openaustralia/scraperwiki-python.git@morph_defaults#egg=scraperwiki
 selenium==2.46.0
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+beautifulsoup4==4.3.2
+python-dateutil==2.4.2
+scraperwiki==0.5
+selenium==2.46.0
+

--- a/scraper.py
+++ b/scraper.py
@@ -27,7 +27,8 @@ driver = webdriver.PhantomJS()
 driver.implicitly_wait(10)
 
 # Create our standard waitable...
-wait = WebDriverWait(driver, 5)
+# At most, wait 30 seconds before exploding with a Timeout exception.
+wait = WebDriverWait(driver, 30)
 
 # Make sure the browser process is shutdown when we exit,
 # whether we die from an error later or not.

--- a/scraper.py
+++ b/scraper.py
@@ -66,15 +66,17 @@ agree_button.click()
 this_week_link = driver.find_elements_by_link_text("This Week")[0]
 this_week_link.click()
 
-# Wait 5 seconds to ensure all is loaded.
-time.sleep(5)
-
+# Wait to ensure all is loaded.
 # Find the "Records per page" selector and select the last value (100).
-records_per_page = driver.find_elements_by_name("applicationsTable_length")[0]
+records_per_page = wait.until(
+    expected_conditions.presence_of_element_located((By.ID, "applicationsTable_length"))
+)
 records_per_page.find_elements_by_tag_name("option")[-1].click()
 
-# Wait 5 seconds to ensure all is loaded.
-time.sleep(5)
+# Wait to ensure all is loaded.
+# Just looking for the "Loading..." popup to appear & vanish.
+wait.until(expected_conditions.visibility_of_element_located((By.ID, "applicationsTable_processing")))
+wait.until(expected_conditions.invisibility_of_element_located((By.ID, "applicationsTable_processing")))
 
 bsd = BeautifulSoup(driver.page_source)
 

--- a/scraper.py
+++ b/scraper.py
@@ -12,24 +12,12 @@ import dateutil.parser
 # To convert relative URLs into absolute URLs
 from urlparse import urljoin
 # To write to SQLite database
-import sqlite3
+import scraperwiki
 # Ensure our cleanup gets called
 import atexit
+import os
 
-# For some reason, scraperwiki wasn't saving to file. Trying plain ol' sqlite3
-database = sqlite3.connect('data.sqlite')
-with database:
-    database.execute("""
-        CREATE TABLE IF NOT EXISTS data (
-            council_reference text unique primary key,
-            address text,
-            description text,
-            info_url text,
-            comment_url text,
-            date_scraped text,
-            date_received text
-        )
-    """)
+os.environ['SCRAPERWIKI_DATABASE_NAME'] = 'sqlite:///data.sqlite'
 
 # Consts
 url = "http://datracker.portstephens.nsw.gov.au/"
@@ -191,25 +179,19 @@ for child in children[1:]:
     """
     on_notice_to = ""
 
-    # Save the record to our database
-    cursor = database.cursor()
-    exists = cursor.execute(
-        "SELECT * FROM data WHERE council_reference=?", (da['council_reference'],)
-    ).fetchone()
-
-    fields = da.keys()
-    placeholders = ','.join(['?'] * len(fields))
-
-    if not exists:
-        print("Saving: " + da['council_reference'])
-        cursor.execute("""
-            INSERT INTO data ({fields}) VALUES ({placeholders})
-        """.format(
-            fields=",".join(fields),
-            placeholders=placeholders
-        ),
-            tuple(da[field] for field in fields)
+    # If this is our first run, the database won't exist yet.
+    # So wrap in a try block.
+    try:
+        already_exists = scraperwiki.sql.select(
+            "* FROM data WHERE council_reference=?", [da['council_reference']]
         )
-        database.commit()
+    except:
+        already_exists = False
+
+    if already_exists:
+        print "Skipping: {}".format(da['council_reference'])
     else:
-        print("Skipping: " + da['council_reference'])
+        print "Saving: {}".format(da['council_reference'])
+        scraperwiki.sql.save(
+            unique_keys=['council_reference'], data=da, table_name="data"
+        )

--- a/scraper.py
+++ b/scraper.py
@@ -156,3 +156,7 @@ for child in children[1:]:
 
     print da
     scraperwiki.sqlite.save(unique_keys=['council_reference'], data=da)
+
+# Shutdown our browser. Don't want any orphaned browsers haunting
+# the system... They don't get killed automatically when we exit.
+driver.quit()

--- a/scraper.py
+++ b/scraper.py
@@ -17,6 +17,7 @@ import scraperwiki
 import atexit
 import os
 
+os.environ['SCRAPERWIKI_DATABASE_NAME'] = 'sqlite:///data.sqlite'
 
 # Consts
 url = "http://datracker.portstephens.nsw.gov.au/"

--- a/scraper.py
+++ b/scraper.py
@@ -191,9 +191,7 @@ for child in children[1:]:
     """
     on_notice_to = ""
 
-    # If this is our first run, the database won't exist yet.
-    # So wrap in a try block.
-
+    # Save the record to our database
     cursor = database.cursor()
     exists = cursor.execute(
         "SELECT * FROM data WHERE council_reference=?", (da['council_reference'],)

--- a/scraper.py
+++ b/scraper.py
@@ -27,6 +27,10 @@ driver.add_cookie({"name": "User", "value": "accessAllowed-MasterView=True"})
 # Refresh the page.
 driver.refresh()
 
+# Ensure all columns are visible. The jquery responsive datatables in use have
+# the "feature" of removing columns, when the window is too narrow.
+driver.set_window_size(1200, 600)
+
 # Find the first "This Week" link. That is "Applications Submitted".
 this_week_link = driver.find_elements_by_link_text("This Week")[0]
 this_week_link.click()

--- a/scraper.py
+++ b/scraper.py
@@ -182,7 +182,7 @@ for child in children[1:]:
     # If this is our first run, the database won't exist yet.
     # So wrap in a try block.
     try:
-        already_exists = scraperwiki.sqlite.select(
+        already_exists = scraperwiki.sql.select(
             "* FROM data WHERE council_reference=?", [da['council_reference']]
         )
     except:
@@ -192,6 +192,6 @@ for child in children[1:]:
         print "Skipping: {}".format(da['council_reference'])
     else:
         print "Saving: {}".format(da['council_reference'])
-        scraperwiki.sqlite.save(
+        scraperwiki.sql.save(
             unique_keys=['council_reference'], data=da, table_name="data"
         )

--- a/scraper.py
+++ b/scraper.py
@@ -187,7 +187,19 @@ for child in children[1:]:
     """
     on_notice_to = ""
 
-    print da
-    scraperwiki.sqlite.save(unique_keys=['council_reference'], data=da)
+    # If this is our first run, the database won't exist yet.
+    # So wrap in a try block.
+    try:
+        already_exists = scraperwiki.sqlite.select(
+            "* FROM data WHERE council_reference=?", [da['council_reference']]
+        )
+    except:
+        already_exists = False
 
-
+    if already_exists:
+        print "Skipping: {}".format(da['council_reference'])
+    else:
+        print "Saving: {}".format(da['council_reference'])
+        scraperwiki.sqlite.save(
+            unique_keys=['council_reference'], data=da, table_name="data"
+        )

--- a/scraper.py
+++ b/scraper.py
@@ -52,15 +52,15 @@ def shutdown_browser():
 # Get the first page with agreement.
 driver.get(url)
 
-# Set the cookie to skip the agreement.
-driver.add_cookie({"name": "User", "value": "accessAllowed-MasterView=True"})
-
-# Refresh the page.
-driver.refresh()
-
 # Ensure all columns are visible. The jquery responsive datatables in use have
 # the "feature" of removing columns, when the window is too narrow.
-driver.set_window_size(1200, 600)
+driver.set_window_size(1280, 1024)
+
+# Set the cookie to skip the agreement.
+agree_button = wait.until(
+    expected_conditions.presence_of_element_located((By.ID, "agree"))
+)
+agree_button.click()
 
 # Find the first "This Week" link. That is "Applications Submitted".
 this_week_link = driver.find_elements_by_link_text("This Week")[0]

--- a/scraper.py
+++ b/scraper.py
@@ -15,7 +15,6 @@ from urlparse import urljoin
 import scraperwiki
 # Ensure our cleanup gets called
 import atexit
-import os
 
 # Consts
 url = "http://datracker.portstephens.nsw.gov.au/"

--- a/scraper.py
+++ b/scraper.py
@@ -54,9 +54,9 @@ agree_button = wait.until(
 )
 agree_button.click()
 
-# Find the first "This Week" link. That is "Applications Submitted".
-this_week_link = driver.find_elements_by_link_text("This Week")[0]
-this_week_link.click()
+# Find the first "This Month" link. That is "Applications Submitted".
+this_month_link = driver.find_elements_by_link_text("This Month")[0]
+this_month_link.click()
 
 # Wait to ensure all is loaded.
 # Find the "Records per page" selector and select the last value (100).

--- a/scraper.py
+++ b/scraper.py
@@ -38,15 +38,6 @@ def shutdown_browser():
     try:
         # Close the driver process
         driver.quit()
-
-        # nuke the service... die, die, die!
-        # For some reason, the PhantomJS driver doesn't manage
-        # to shutdown its service process. :( We're going to force
-        # it ourselves, so zombie phantoms don't haunt all our memory.
-        # From the code, it seems that it should, but sounds like
-        # it's a common issue with phantomjs. Best we can do for now
-        # is bring down the hammer...
-        os.system("killall phantomjs")
     except Exception, err:
         print("Failed to kill client browser: " + str(err))
 

--- a/scraper.py
+++ b/scraper.py
@@ -17,8 +17,6 @@ import scraperwiki
 import atexit
 import os
 
-os.environ['SCRAPERWIKI_DATABASE_NAME'] = 'sqlite:///data.sqlite'
-
 # Consts
 url = "http://datracker.portstephens.nsw.gov.au/"
 


### PR DESCRIPTION
Switched to phantom, since I think that this headless browser is the only one available on morph.

Other minor change:
- set the browser size, since the jquery responsive datatable widget on the target page _removes columns_ when the window is too narrow.  Yikes.

Maybe less minor:
- Switched to plain sqlite to save the data, replacing scraperwiki.  For some reason scraperwiki's save() function wasn't saving.  Or maybe it was, but to the wrong file?  Either way, the results weren't being displayed on morph.  Worth investigating the why (I probably missed something obvious), but it's working as it is now.
